### PR TITLE
min base markers

### DIFF
--- a/Ruleset/ufos_XCOMFILES.rul
+++ b/Ruleset/ufos_XCOMFILES.rul
@@ -1719,6 +1719,8 @@
     reload: 32
     breakOffTime: 500
     hitBonus: 10
+    marker: 14
+    markerLand: 12
     battlescapeTerrainData:
       name: MBASE01
       mapDataSets:


### PR DESCRIPTION
choosing a number from Resources\TerrainPack\Geoscape\globe_ufo_expanded.png
here are ingame images (base is blinking as all bases do)
![1](https://user-images.githubusercontent.com/45336117/62225814-d4195200-b3c1-11e9-90f1-ca5269865dce.PNG)
![2](https://user-images.githubusercontent.com/45336117/62225823-d8de0600-b3c1-11e9-9e42-5bc783f9a8b1.PNG)
