### PR TITLE
change webwear minimum to kinetic, from none

### DIFF
--- a/Ruleset/scripts_XCOMFILES.rul
+++ b/Ruleset/scripts_XCOMFILES.rul
@@ -153,7 +153,7 @@ items:
   - type: STR_WEBWEAR
     tags:
       ITEM_RESIST_TYPE_1: 80
-      ITEM_MINIMUM_RESIST_TYPE_0: 50
+      ITEM_MINIMUM_RESIST_TYPE_1: 50
       ITEM_RESIST_SLOT_INDEX: 1
 
 #--------------------------------------------------------------------------------------------


### PR DESCRIPTION
None dmg resistance was affecting sanity. Anyone wearing webwear was immune to sanity loss.