### PR TITLE
costBuy/requiresBuy mismatches

### DIFF
--- a/Ruleset/items_XCOMFILES.rul
+++ b/Ruleset/items_XCOMFILES.rul
@@ -4026,8 +4026,6 @@
     listOrder: 17900
   - type: STR_BONE_CLUB
     categories: [STR_HUMAN_TECH, STR_MELEE, STR_INCAPACITATE, STR_CONCEALABLE, STR_SPACE, STR_LAND]
-    requiresBuy:
-      - STR_BONE_CLUB
     size: 0.1
     costSell: 1000
     weight: 7
@@ -5019,6 +5017,7 @@
     requiresBuy:
       - STR_NAPALM_GRENADE
     size: 0.1
+    costBuy: 500
     costSell: 400
     weight: 3
     bigSprite: 868


### PR DESCRIPTION
Napalm grenade had no price, and therefore wasn't purchasable. Added price at same ratio as incendiary grenade.
Bone club had a tech requirement to purchase, but no price. Removed the tech requirement to avoid confusion.