### PR TITLE
Fixed Assault Plasma

### DIFF
--- a/Ruleset/items_XCOMFILES.rul
+++ b/Ruleset/items_XCOMFILES.rul
@@ -11811,7 +11811,7 @@
     attraction: 11
     listOrder: 21914
   - type: STR_XCOM_ASSAULT_PLASMA_CLIP
-    categories: [STR_HUMAN_TECH, STR_PLASMA, STR_HEAVY_WEAPONS, STR_RIFLES, STR_SPACE, STR_LAND, STR_LAND]
+    categories: [STR_HUMAN_TECH, STR_PLASMA, STR_HEAVY_WEAPONS, STR_RIFLES, STR_SPACE, STR_LAND]
     size: 0.3
     costSell: 10600
     weight: 3
@@ -11839,7 +11839,7 @@
     attraction: 11
     listOrder: 21915
   - type: STR_XCOM_ASSAULT_PLASMA_GRENADE
-    categories: [STR_SHOTGUNS, STR_HUMAN_TECH, STR_SONIC, STR_CLIPS, STR_UNDERWATER, STR_SPACE, STR_LAND]
+    categories: [STR_HUMAN_TECH, STR_LAUNCHERS, STR_EXPLOSIVES, STR_CLIPS, STR_SPACE, STR_LAND]
     size: 0.5
     costSell: 9000
     weight: 3


### PR DESCRIPTION
This should fix the remaining anomalous categories for the X-COM Assault Plasma grenades, as well as an accidental category duplication in the X-COM Assault Plasma clip. 