### PR TITLE
Duplicate armor anchors

### DIFF
--- a/Ruleset/armors_XCOMFILES.rul
+++ b/Ruleset/armors_XCOMFILES.rul
@@ -84,22 +84,7 @@
         health: -0.05
     createsMeleeThreat: true
     damageModifier:
-      - 1.0
-      - 1.0
-      - 2.0
-      - 0.8
-      - 1.0
-      - 1.0
-      - 0.5
-      - 1.0
-      - 0.2
-      - 2.0
-      - 0.1
-      - 1.2
-      - 0.7
-      - 1.0
-      - 0.0
-      - 1.0
+  JumpArmorResists
     loftempsSet: [ 92, 89, 90, 91 ]
   - type: STR_SWARMIDS_LARGE_ARMOR
     spriteSheet: SWARMIDS_LARGE.PCK
@@ -23474,23 +23459,7 @@
       health:
         stunNormalized: -0.1
     overKill: 1.5
-    damageModifier: &AlloyVestShieldResists
-      - 1.0
-      - 0.8
-      - 1.0
-      - 1.0
-      - 0.8
-      - 1.0
-      - 0.9
-      - 1.0
-      - 1.0
-      - 4.0
-      - 0.1
-      - 0.8
-      - 1.0
-      - 1.0
-      - 0.0
-      - 1.0
+    damageModifier: *AlloyVestShieldResists
     specialWeapon: STR_UNARMED_ALLOY_VEST_SHIELD
     units:
       - STR_OLYMPIAN
@@ -23986,23 +23955,7 @@
       health:
         stunNormalized: -0.1
     overKill: 1.5
-    damageModifier: &VestBusinessSuitResists
-      - 1.0
-      - 0.8
-      - 1.5
-      - 1.0
-      - 1.0
-      - 1.0
-      - 1.0
-      - 1.0
-      - 1.0
-      - 4.0
-      - 0.1
-      - 1.0
-      - 1.0
-      - 1.0
-      - 0.0
-      - 1.0
+    damageModifier: *VestBusinessSuitResists
     specialWeapon: STR_UNARMED_SUIT_VEST
     units:
       - STR_OLYMPIAN
@@ -26543,23 +26496,7 @@
       health:
         stunNormalized: -0.1
     overKill: 1.5
-    damageModifier: &JumpArmorResists
-      - 1.0
-      - 1.0
-      - 0.8
-      - 0.85
-      - 0.8
-      - 0.65
-      - 0.9
-      - 0.7
-      - 1.0
-      - 4.0
-      - 0.25
-      - 0.6
-      - 1.0
-      - 1.0
-      - 0.0
-      - 1.0
+    damageModifier: *JumpArmorResists
     specialWeapon: STR_UNARMED_JUMP_ARMOR
     units:
       - STR_OLYMPIAN
@@ -27964,23 +27901,7 @@
       health:
         stunNormalized: -0.1
     overKill: 1.5
-    damageModifier: &SynthsuitResists
-      - 1.0
-      - 0.8
-      - 1.3
-      - 0.8
-      - 1.1
-      - 1.1
-      - 1.0
-      - 0.7
-      - 1.2
-      - 1.0
-      - 0.1
-      - 1.0
-      - 1.0
-      - 1.0
-      - 0.0
-      - 1.0
+    damageModifier: *SynthsuitResists
     specialWeapon: STR_UNARMED_SYNTHSUIT
     units:
       - STR_OLYMPIAN
@@ -30294,23 +30215,7 @@
       health:
         stunNormalized: -0.1
     overKill: 1.5
-    damageModifier: &AnchorFlyingSuitRes
-      - 1.0
-      - 1.15
-      - 0.1
-      - 0.9
-      - 1.0
-      - 0.85
-      - 0.8
-      - 1.0
-      - 1.0
-      - 0.0
-      - 0.65
-      - 0.2
-      - 1.0
-      - 0.9
-      - 0.0
-      - 1.0
+    damageModifier: *AnchorFlyingSuitRes
     specialWeapon: STR_UNARMED_FLYING_SUIT
     builtInWeapons:
       - INV_JETPACK_B_3X3
@@ -31461,23 +31366,7 @@
       health:
         stunNormalized: -0.1
     overKill: 1.5
-    damageModifier: &AnchorJuggernautSuitRes
-      - 1.0
-      - 0.9
-      - 0.1
-      - 0.8
-      - 1.0
-      - 0.9
-      - 0.8
-      - 0.9
-      - 1.0
-      - 0.0
-      - 0.5
-      - 0.2
-      - 1.0
-      - 1.0
-      - 0.0
-      - 1.0
+    damageModifier: *AnchorJuggernautSuitRes
     specialWeapon: STR_UNARMED_JUGGERNAUT
     units:
       - STR_OLYMPIAN


### PR DESCRIPTION
UAC_SpaceMarineGear in alienDeployments is also defined twice, but with slight differences, so you should look at that one yourself.