### PR TITLE
Allowed armors typos

### DIFF
--- a/Ruleset/startingConditions_XCOMFILES.rul
+++ b/Ruleset/startingConditions_XCOMFILES.rul
@@ -1,4 +1,4 @@
-﻿startingConditions:
+startingConditions:
   - type: STR_SPACE
     defaultArmor:
       STR_SOLDIER:
@@ -67,7 +67,6 @@
       - STR_SECTOPOD_ARMOR2
       - STR_SECTOPOD_ARMOR3
       - STR_SECTOPOD_MINIGUN_ARMOR
-      - XCOM_CYBERDISC_ARMOR
       - STR_XCOM_CYBERDISC_ARMOR_ORANGE
       - STR_GUNSHIP_ARMOR_UC
       - STR_ENFORCER_ARMOR_UC
@@ -122,7 +121,7 @@
       - STR_POLAR_SUIT_PROTEAN_UC
       - STR_POLAR_SUIT_H_UC
       - STR_DOGE_ARMOR
-      - STR_RAT_ARMOR
+      - STR_XCOM_RAT_ARMOR
     allowedItemCategories:
       - STR_SPORTS
     allowedVehicles:
@@ -153,7 +152,7 @@
       - STR_WORKSUIT_PROTEAN_UC
       - STR_WORKSUIT_H_UC
       - STR_DOGE_ARMOR
-      - STR_RAT_ARMOR
+      - STR_XCOM_RAT_ARMOR
     allowedItemCategories:
       - STR_LABOR
     allowedVehicles:
@@ -253,7 +252,6 @@
       - STR_SECTOPOD_ARMOR2
       - STR_SECTOPOD_ARMOR3
       - STR_SECTOPOD_MINIGUN_ARMOR
-      - XCOM_CYBERDISC_ARMOR
       - STR_XCOM_CYBERDISC_ARMOR_ORANGE
       - STR_GUNSHIP_ARMOR_UC
       - STR_ENFORCER_ARMOR_UC
@@ -392,7 +390,7 @@
       - STR_SUIT_PROTEAN_UC
       - STR_SUIT_H_UC
       - STR_DOGE_ARMOR
-      - STR_RAT_ARMOR
+      - STR_XCOM_RAT_ARMOR
     allowedItemCategories:
       - STR_CONCEALABLE
     allowedVehicles:
@@ -513,10 +511,10 @@
       STR_MUGGLE_AI:
         STR_SMALL_TANK_ARMOR: 100
     allowedArmors:
-      - STR_CAVEMAN_DISGUISE_UC_UC
+      - STR_CAVEMAN_DISGUISE_UC
       - STR_CAVEMAN_DISGUISE_OLYMPIAN_UC
       - STR_CAVEMAN_DISGUISE_PROTEAN_UC
-      - STR_CAVEMAN_DISGUISE_UC_H_UC
+      - STR_CAVEMAN_DISGUISE_H_UC
       - STR_DOGE_ARMOR
       - STR_XCOM_RAT_ARMOR
     allowedCraft:


### PR DESCRIPTION
STR_XCOM_CYBERDISC_ARMOR was in those lists twice