### PR TITLE
confAuto on weapon that can only snap-fire

### DIFF
--- a/Ruleset/items_XCOMFILES.rul
+++ b/Ruleset/items_XCOMFILES.rul
@@ -1,4 +1,4 @@
-﻿items:
+items:
   - delete: STR_LASER_PISTOL
   - delete: STR_LASER_RIFLE
   - delete: STR_HEAVY_LASER
@@ -35335,7 +35335,7 @@
     accuracyCloseQuarters: 130
     accuracySnap: 80
     tuSnap: 66
-    confAimed:
+    confSnap:
       shots: 2
     battleType: 1
     maxRange: 12


### PR DESCRIPTION
Changing it to confSnap causes the snakes to fire twice with their ranged attack.