### PR TITLE
Missing string on MiB pilot

### DIFF
--- a/Ruleset/ufopaedia_XCOMFILES.rul
+++ b/Ruleset/ufopaedia_XCOMFILES.rul
@@ -7856,7 +7856,6 @@ ufopaedia:
     section: STR_ALIEN_LIFE_FORMS
     requires:
       - STR_MIB_PILOT_ARMOR
-    text: STR_MIB_PILOT_ARMOR_UFOPEDIA
     listOrder: 146081
   - id: STR_MIB_HEAVY_TROOPER
     type_id: 7


### PR DESCRIPTION
None of the combat analysis articles have strings, so I just removed it to avoid showing "STR_MIB_PILOT_ARMOR_UFOPEDIA"