### PR TITLE
Add 'Stun Weapons' Category to guns that have baton ammo

### DIFF
--- a/Ruleset/items_XCOMFILES.rul
+++ b/Ruleset/items_XCOMFILES.rul
@@ -1976,7 +1976,7 @@ items:
     invHeight: 1
     listOrder: 10983
   - type: STR_SCOUT_VEHICLE_SHOTGUN_BATON_CLIP
-    categories: [STR_HUMAN_TECH, STR_AUXILIARY, STR_SPACE, STR_CLIPS]
+    categories: [STR_HUMAN_TECH, STR_AUXILIARY, STR_INCAPACITATE, STR_SPACE, STR_CLIPS]
     size: 0.3
     costSell: 100
     transferTime: 12
@@ -15385,7 +15385,7 @@ items:
     attraction: 15
     listOrder: 22452
   - type: STR_KS23
-    categories: [STR_HUMAN_TECH, STR_FIREARMS, STR_SHOTGUNS, STR_LAND]
+    categories: [STR_HUMAN_TECH, STR_FIREARMS, STR_SHOTGUNS, STR_INCAPACITATE, STR_LAND]
     requiresBuy:
       - STR_KS23_BUY
     size: 0.25
@@ -15466,7 +15466,7 @@ items:
     attraction: 15
     listOrder: 22455
   - type: STR_KS23_SHELLS_BATON
-    categories: [STR_HUMAN_TECH, STR_FIREARMS, STR_SHOTGUNS, STR_CLIPS, STR_LAND]
+    categories: [STR_HUMAN_TECH, STR_FIREARMS, STR_SHOTGUNS, STR_INCAPACITATE, STR_CLIPS, STR_LAND]
     requiresBuy:
       - STR_KS23_BUY
     size: 0.1
@@ -17741,7 +17741,7 @@ items:
     attraction: 15
     listOrder: 22620
   - type: STR_WINCHESTER_1901
-    categories: [STR_HUMAN_TECH, STR_FIREARMS, STR_SHOTGUNS, STR_LAND]
+    categories: [STR_HUMAN_TECH, STR_FIREARMS, STR_SHOTGUNS, STR_INCAPACITATE, STR_LAND]
     requiresBuy:
       - STR_WINCHESTER_1901_BUY
     size: 0.2
@@ -17777,7 +17777,7 @@ items:
     attraction: 20
     listOrder: 22470
   - type: STR_SHOTGUN
-    categories: [STR_HUMAN_TECH, STR_FIREARMS, STR_SHOTGUNS, STR_LAND]
+    categories: [STR_HUMAN_TECH, STR_FIREARMS, STR_SHOTGUNS, STR_INCAPACITATE, STR_LAND]
     requiresBuy:
       - STR_SHOTGUN_BUY
     size: 0.2
@@ -17815,7 +17815,7 @@ items:
     attraction: 20
     listOrder: 22520
   - type: STR_BLACKOPS_SHOTGUN
-    categories: [STR_HUMAN_TECH, STR_FIREARMS, STR_SHOTGUNS, STR_LAND]
+    categories: [STR_HUMAN_TECH, STR_FIREARMS, STR_SHOTGUNS, STR_INCAPACITATE, STR_LAND]
     requiresBuy:
       - STR_BLACKOPS_SHOTGUN_BUY
     size: 0.2
@@ -19381,7 +19381,7 @@ items:
     attraction: 15
     listOrder: 23420
   - type: STR_CAWS
-    categories: [STR_HUMAN_TECH, STR_SHOTGUNS, STR_FIREARMS, STR_LAND]
+    categories: [STR_HUMAN_TECH, STR_SHOTGUNS, STR_FIREARMS, STR_INCAPACITATE, STR_LAND]
     requiresBuy:
       - STR_CAWS_BUY
     size: 0.2
@@ -19465,7 +19465,7 @@ items:
     attraction: 15
     listOrder: 22656
   - type: STR_CAWS_CLIP_BATON
-    categories: [STR_HUMAN_TECH, STR_SHOTGUNS, STR_FIREARMS, STR_CLIPS, STR_LAND]
+    categories: [STR_HUMAN_TECH, STR_SHOTGUNS, STR_FIREARMS, STR_INCAPACITATE, STR_CLIPS, STR_LAND]
     requiresBuy:
       - STR_CAWS_BUY
     size: 0.05


### PR DESCRIPTION
Add 'Stun Weapons' Category to:
 - 'Winchester Model 1901', 'Shotgun' and 'BlackOps Shotgun', since they have 'Shotgun Baton Shells' in that category.
 - 'BlackOps CAWS' and 'BlackOps CAWS Baton Clip'
 - 'KS-23M' and 'KS-23M Baton Shells'
 - 'Scout Vehicle Shotgun Baton Clip'